### PR TITLE
fix: update collateral for move from beta

### DIFF
--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -38,7 +38,7 @@ const appRoutes: AppRouteConfig<any>[] = [
     path: '/streams/kafkas/:id',
     title: 'Red Hat OpenShift Streams for Apache Kafka',
     basename: '/streams/kafkas/:id',
-    devPreview: true,
+    devPreview: false,
   },
   {
     // Handle the redirect from application-services/streams to application-services/streams/kafkas
@@ -63,7 +63,7 @@ const appRoutes: AppRouteConfig<any>[] = [
     path: '/streams/kafkas',
     title: 'Red Hat OpenShift Streams for Apache Kafka',
     basename: '/streams/kafkas',
-    devPreview: true,
+    devPreview: false,
   },
   {
     component: ServiceRegistryPage,
@@ -143,7 +143,7 @@ const appRoutes: AppRouteConfig<any>[] = [
     label: 'Red Hat OpenShift Streams for Apache Kafka',
     path: '/service-accounts',
     title: 'Red Hat OpenShift Streams for Apache Kafka',
-    devPreview: true,
+    devPreview: false,
   },
   {
     component: RedirectToServiceAccounts,
@@ -151,7 +151,7 @@ const appRoutes: AppRouteConfig<any>[] = [
     label: 'Red Hat OpenShift Streams for Apache Kafka',
     path: '/streams/service-accounts',
     title: 'Red Hat OpenShift Streams for Apache Kafka',
-    devPreview: true,
+    devPreview: false,
   },
   {
     component: OverviewPage,
@@ -197,7 +197,7 @@ const appRoutes: AppRouteConfig<any>[] = [
     label: 'Learning Resources | Red Hat OpenShift Application Services',
     path: '/learning-resources',
     title: 'Learning Resources | Red Hat OpenShift Application Services',
-    devPreview: true,
+    devPreview: false,
   },
 ];
 

--- a/src/app/pages/Overview/OverviewPage.tsx
+++ b/src/app/pages/Overview/OverviewPage.tsx
@@ -41,23 +41,15 @@ export const OverviewPage: React.FunctionComponent = () => {
   const beta = location.pathname.startsWith('/beta');
 
   const onClickKafkainstance = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    if (beta) {
-      event.preventDefault();
-      history.push(`${basename}/streams/kafkas`);
-    }
+    event.preventDefault();
+    history.push(`${basename}/streams/kafkas`);
   }
 
   const getKafkaHref = () => {
-    if (beta) {
-      return history.createHref({
-        pathname: '/streams/kafkas'
-      })
-    }
-    return '/beta/application-services/streams/kafkas'
+    return history.createHref({
+      pathname: '/streams/kafkas'
+    })
   }
-
-
-
 
   const onClickServiceRegistry = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (beta) {
@@ -129,9 +121,6 @@ export const OverviewPage: React.FunctionComponent = () => {
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <Label color="blue">{t('overview.generalAvailability')}</Label>
-                </StackItem>
                 <StackItem>
                   {t('overview.rhoamMainText')}
                 </StackItem>
@@ -237,9 +226,6 @@ export const OverviewPage: React.FunctionComponent = () => {
             </CardTitle>
             <CardBody>
               <Stack hasGutter>
-                <StackItem className="pf-u-mb-lg">
-                  <Label>{t('overview.developmentPreview')}</Label>
-                </StackItem>
                 <StackItem>
                   {t('overview.rhosakMainText')}
                 </StackItem>


### PR DESCRIPTION
* remove status labels from Red Hat OpenShift Streams for Apache Kafka and Red Hat OpenShift API Management
* Make links to Kafka go to prod-stable
* Remove development preview banner from service accounts, Kafka and Learning resources

Fixes https://issues.redhat.com/browse/MGDSTRM-6008