### PR TITLE
chore: terms and conditions spec

### DIFF
--- a/static/configs/terms-conditions-spec.json
+++ b/static/configs/terms-conditions-spec.json
@@ -1,12 +1,10 @@
 {
   "kafka":{
      "EventCode":"register",
-     "SiteCode":"ocm",
-     "StopOnTermsChange": true
+     "SiteCode":"ocm"
   },
   "service-registry":{
      "EventCode":"onlineService",
-     "SiteCode":"ocm",
-     "StopOnTermsChange": true
+     "SiteCode":"ocm"
   }
 }

--- a/static/configs/terms-conditions-spec.json
+++ b/static/configs/terms-conditions-spec.json
@@ -1,0 +1,12 @@
+{
+  "kafka":{
+     "EventCode":"register",
+     "SiteCode":"ocm",
+     "StopOnTermsChange": true
+  },
+  "service-registry":{
+     "EventCode":"onlineService",
+     "SiteCode":"ocm",
+     "StopOnTermsChange": true
+  }
+}

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -55,9 +55,13 @@ module.exports = merge(common("production", { mode: "production", publicPath }),
           from: 'static/images/Logo-Red_Hat-OpenShift_Streams_for_Apache_Kafka-A-Reverse-RGB-310x117.png',
           to: 'Logo-Red_Hat-OpenShift_Streams_for_Apache_Kafka-A-Reverse-RGB-310x117.png'
         },
-        {
+        { 
           from: 'static/images/Logo-Red_Hat-OpenShift-API_Management-A-Standard-RGB.svg',
           to: 'Logo-Red_Hat-OpenShift-API_Management-A-Standard-RGB.svg'
+        },
+        {
+          from: 'static/configs/terms-conditions-spec.json',
+          to: 'terms-conditions-spec.json'
         }
       ]
     })


### PR DESCRIPTION
Adding specification for terms and conditions. Purpose of this change is to host this file remotely and access it from multiple clients like CLI, UI etc.

In for go files structure will look like:

```
type TermsAndConditionsSpec struct {
	Kafka           ServiceTermsSpec `json:"kafka"`
	ServiceRegistry ServiceTermsSpec `json:"service-registry"`
}

type ServiceTermsSpec struct {
	EventCode         string `json:"EventCode"`
	SiteCode          string `json:"SiteCode"`
	StopOnTermsChange bool   `json:"StopOnTermsChange"`
}
```

We might need to add that to SDK along with AMS SDK