### PR TITLE
Adding translation for cancel modal in the Access tab

### DIFF
--- a/src/locales/kafka-ui.json
+++ b/src/locales/kafka-ui.json
@@ -180,6 +180,12 @@
       "permissions_column_title": "Permission",
       "account_column_title": "Account"
     },
+    "manage_permissions_pre_cancel_dialog": {
+      "aria_label": "Pre cancel manage access dialog",
+      "discard_changes": "Discard changes",
+      "resume_editing": "Resume editing",
+      "modal_description": "Any changes you made to access permissions will be lost."
+    },
     "manage_permissions_dialog": {
       "title": "Manage access",
       "aria_label": "Manage access dialog",


### PR DESCRIPTION
Adding translation for cancel modal in the Access tab

![Screenshot from 2021-12-17 19-57-55](https://user-images.githubusercontent.com/53568062/146559303-036ce068-1623-4bbf-8502-06373e378a3c.png)
