### PR TITLE
fix: vscode hangs when trying to run project with local dev

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,5 @@
     "**/*.jsx",
     "**/*.js"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "modules"]
 }


### PR DESCRIPTION
Running project with all federated UIs source code hangs both Vscode and InteliJ
This happens due to large number of typescript files that are not excluded