### PR TITLE
fix: make the local development workflow work again

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,27 +1,33 @@
 {
   "federatedModules": {
     "kas": {
-      "basePath": "http://localhost:9000",
+      "basePath": "/mas-local-fm/kas",
+      "proxyTarget": "http://localhost:9000",
       "fallbackBasePath": "/beta/apps/rhosak-control-plane-ui-build"
     },
     "kafka": {
-      "basePath": "http://localhost:8080",
+      "basePath": "/mas-local-fm/kafka",
+      "proxyTarget": "http://localhost:8080",
       "fallbackBasePath": "/beta/apps/rhosak-data-plane-ui-build"
     },
     "guides": {
-      "basePath": "http://localhost:9001",
+      "basePath": "/mas-local-fm/guides",
+      "proxyTarget": "http://localhost:9001",
       "fallbackBasePath": "/beta/apps/rhoas-guides-build"
     },
     "apicurio_registry": {
-      "basePath": "http://localhost:8888",
+      "basePath": "/mas-local-fm/apicurio_registry",
+      "proxyTarget": "http://localhost:8888",
       "fallbackBasePath": "/beta/apps/sr-ui-build"
     },
     "srs": {
-      "basePath": "http://localhost:9005",
+      "basePath": "/mas-local-fm/srs",
+      "proxyTarget": "http://localhost:9005",
       "fallbackBasePath": "/beta/apps/srs-ui-build"
     },
     "cos": {
-      "basePath": "http://localhost:9002",
+      "basePath": "/mas-local-fm/cos",
+      "proxyTarget": "http://localhost:9002",
       "fallbackBasePath": "/beta/apps/cos-ui-build"
     }
   },

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,75 +1,89 @@
-const { merge } = require("webpack-merge");
-const common = require("./webpack.common.js");
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
 const CopyPlugin = require('copy-webpack-plugin');
 const { port, crc } = require('./package.json');
 const proxy = require('@redhat-cloud-services/frontend-components-config-utilities/proxy');
-const HOST = process.env.HOST || "localhost";
+const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || port;
 const BETA = true;
 
-const basePublicPath = `${BETA ? '/beta' : ''}/apps`
-const proxyPublicPath = `${BETA ? '/beta' : ''}/${crc.bundle}/`
+const config = require('./config/config.json');
+
+const basePublicPath = `${BETA ? '/beta' : ''}/apps`;
+const proxyPublicPath = `${BETA ? '/beta' : ''}/${crc.bundle}/`;
 const publicPath = `${basePublicPath}/${crc.bundle}/`;
 
-module.exports = merge(common('development', {
-  publicPath, beta: BETA
-}), {
-
-  mode: "development",
-  devtool: "eval-source-map",
-  devServer: {
-    static: {
-      publicPath,
-      directory: "./dist",
+module.exports = merge(
+  common('development', {
+    publicPath,
+    beta: BETA,
+  }),
+  {
+    mode: 'development',
+    devtool: 'eval-source-map',
+    devServer: {
+      static: {
+        publicPath,
+        directory: './dist',
+      },
+      host: HOST,
+      port: PORT,
+      compress: true,
+      historyApiFallback: {
+        index: `${publicPath}index.html`,
+      },
+      hot: true,
+      client: {
+        overlay: true,
+        webSocketURL: 'ws://localhost:7003/ws',
+      },
+      webSocketServer: {
+        type: 'ws',
+        options: {
+          host: 'localhost',
+          port: 7003,
+          path: '/ws',
+        },
+      },
+      open: {
+        target: [`https://prod.foo.redhat.com:1337${BETA ? '/beta' : ''}/${crc.bundle}/`],
+      },
+      allowedHosts: 'all',
+      devMiddleware: {
+        publicPath,
+      },
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+        'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
+      },
+      ...proxy({
+        useProxy: true,
+        useCloud: false,
+        env: BETA ? 'prod-beta' : 'prod-stable',
+        standalone: false,
+        publicPath: proxyPublicPath,
+        proxyVerbose: true,
+        customProxy: Object.values(config.federatedModules).map((config) => ({
+          context: (path) => path.includes(config.basePath),
+          target: config.proxyTarget,
+          secure: false,
+          changeOrigin: true,
+          autoRewrite: true,
+          ws: true,
+          pathRewrite: { [`^${config.basePath}`]: '' },
+        })),
+      }),
     },
-    host: HOST,
-    port: PORT,
-    compress: true,
-    historyApiFallback: {
-      index: `${publicPath}index.html`
-    },
-    hot: true,
-    client: {
-      overlay: true,
-      webSocketURL: 'ws://localhost:7003/ws'
-    },
-    webSocketServer: {
-      type: "ws",
-      options: {
-        host: "localhost",
-        port: 7003,
-        path: "/ws"
-      }
-    },
-    open: {
-      target: [`https://prod.foo.redhat.com:1337${BETA ? '/beta' : ''}/${crc.bundle}/`]
-    },
-    allowedHosts: "all",
-    devMiddleware: {
-      publicPath,
-    },
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-      "Access-Control-Allow-Headers": "X-Requested-With, content-type, Authorization"
-    },
-    ...proxy({
-      useProxy: true,
-      useCloud: false,
-      env: BETA ? 'prod-beta' : 'prod-stable',
-      standalone: false,
-      publicPath: proxyPublicPath,
-      proxyVerbose: true
-    })
-  },
-  plugins: [
-    new CopyPlugin({
-      patterns: [
-        {
-          from: 'config/config.json',
-          to: `config.json`
-        }
-      ]
-    })
-  ]
-});
+    plugins: [
+      new CopyPlugin({
+        patterns: [
+          {
+            from: 'config/config.json',
+            to: `config.json`,
+          },
+        ],
+      }),
+    ],
+  }
+);


### PR DESCRIPTION
console.redhat.com is now being served with a CSP header that disables any javascript coming from sources not listed in the policy.
We load the federated modules from localhost (many ports) when running the local dev environment, the CSP breaks this behavior.

To fix it, we need to make the app ask for the resources through a pre-defined path, and then proxy the request to the right local server.
To do this the config.json contains a new basePath property that specifies the pre-defined path mentioned before, and a new proxyTarget property
that contains where the proxy should point to fetch the resources for all requests that contains the pre-defined path.