### PR TITLE
chore: make the Kafka admin server URL configurable

### DIFF
--- a/src/app/pages/Kafka/kafka-instance.ts
+++ b/src/app/pages/Kafka/kafka-instance.ts
@@ -3,7 +3,7 @@ import { Configuration, DefaultApi, KafkaRequest } from '@rhoas/kafka-management
 import { useParams } from 'react-router-dom';
 import { useAuth, useConfig } from '@rhoas/app-services-ui-shared';
 
-const DEFAULT_ADMIN_SERVER_URL_TEMPLATE = 'https://admin-server-{}/rest';
+const DEFAULT_ADMIN_SERVER_URL_TEMPLATE = 'https://admin-server-{}/';
 
 /**
  * Join admin server url template with the kafka bootstrap host and return the kafka admin url.

--- a/src/app/pages/Kafka/kafka-instance.ts
+++ b/src/app/pages/Kafka/kafka-instance.ts
@@ -3,11 +3,21 @@ import { Configuration, DefaultApi, KafkaRequest } from '@rhoas/kafka-management
 import { useParams } from 'react-router-dom';
 import { useAuth, useConfig } from '@rhoas/app-services-ui-shared';
 
-export const getAdminServerUrl = (kafkaRequest?: KafkaRequest): string => {
+const DEFAULT_ADMIN_SERVER_URL_TEMPLATE = 'https://admin-server-{}/rest';
+
+/**
+ * Join admin server url template with the kafka bootstrap host and return the kafka admin url.
+ *
+ * @param adminServerUrlTemplate The template that will be used to generate the full admin url from the kafka bootstrap_server_host.
+ *                               The template must have a '{}' placeholder that will be substitute with the bootstrap_server_host.
+ * @param kafkaRequest KafkaRequest
+ * @returns The admin server full URL included the protocol and base path
+ */
+export const getAdminServerUrl = (adminServerUrlTemplate: string, kafkaRequest?: KafkaRequest): string => {
   if (kafkaRequest === undefined) {
     throw new Error('kafkaRequest cannot be undefined');
   }
-  return `https://admin-server-${kafkaRequest?.bootstrap_server_host}/rest`;
+  return adminServerUrlTemplate.replace('{}', kafkaRequest.bootstrap_server_host || '');
 };
 
 export type KafkaInstance = {
@@ -44,7 +54,10 @@ export const useKafkaInstance = (): KafkaInstance | false | undefined => {
   return kafkaRequest
     ? {
         kafkaDetail: kafkaRequest as Required<KafkaRequest>,
-        adminServerUrl: getAdminServerUrl(kafkaRequest),
+        adminServerUrl: getAdminServerUrl(
+          config.kafka?.adminServerUrlTemplate || DEFAULT_ADMIN_SERVER_URL_TEMPLATE,
+          kafkaRequest
+        ),
       }
     : kafkaRequest;
 };

--- a/src/app/pages/Kafka/kafka-instance.ts
+++ b/src/app/pages/Kafka/kafka-instance.ts
@@ -3,7 +3,7 @@ import { Configuration, DefaultApi, KafkaRequest } from '@rhoas/kafka-management
 import { useParams } from 'react-router-dom';
 import { useAuth, useConfig } from '@rhoas/app-services-ui-shared';
 
-const DEFAULT_ADMIN_SERVER_URL_TEMPLATE = 'https://admin-server-{}/';
+const DEFAULT_ADMIN_SERVER_URL_TEMPLATE = 'https://admin-server-{}';
 
 /**
  * Join admin server url template with the kafka bootstrap host and return the kafka admin url.


### PR DESCRIPTION
**Why**

When deploying the UI in a different environment from stage or production the Kafka admin server route and/or protocol can change and therefore we must be able to re-configure it in the UI

Blocked: https://github.com/redhat-developer/app-services-ui-shared/pull/117