### PR TITLE
downgrade  sdk (kafka-instance-sdk) which breaks admin api on dashboard page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rhoas/account-management-sdk": "0.27.0",
         "@rhoas/app-services-ui-components": "1.24.0",
         "@rhoas/app-services-ui-shared": "0.15.4",
-        "@rhoas/kafka-instance-sdk": "0.27.0",
+        "@rhoas/kafka-instance-sdk": "0.23.2",
         "@rhoas/kafka-management-sdk": "0.27.0",
         "@rhoas/registry-management-sdk": "0.27.0",
         "classnames": "2.3.1",
@@ -1360,19 +1360,19 @@
       }
     },
     "node_modules/@rhoas/kafka-instance-sdk": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@rhoas/kafka-instance-sdk/-/kafka-instance-sdk-0.27.0.tgz",
-      "integrity": "sha512-0l3jU8tNo8je1c+RO/KaWq/FuZHClJ9CRRLlrGciUIchPcKVjte2rYnv2NVQ/la16A5Vd2kYvd4x9wWfdlWa+Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@rhoas/kafka-instance-sdk/-/kafka-instance-sdk-0.23.2.tgz",
+      "integrity": "sha512-v3YHORv30/L7oUpceNgbnuzCJyAyTrK0DJU+mNwx1jm1NpFqyb+dlmDmuRPQR41kMaaQ9ven/ed6jzallC3QoA==",
       "dependencies": {
-        "axios": "0.26.0"
+        "axios": "0.25.0"
       }
     },
     "node_modules/@rhoas/kafka-instance-sdk/node_modules/axios": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
-      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/@rhoas/kafka-management-sdk": {
@@ -14067,19 +14067,19 @@
       }
     },
     "@rhoas/kafka-instance-sdk": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@rhoas/kafka-instance-sdk/-/kafka-instance-sdk-0.27.0.tgz",
-      "integrity": "sha512-0l3jU8tNo8je1c+RO/KaWq/FuZHClJ9CRRLlrGciUIchPcKVjte2rYnv2NVQ/la16A5Vd2kYvd4x9wWfdlWa+Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@rhoas/kafka-instance-sdk/-/kafka-instance-sdk-0.23.2.tgz",
+      "integrity": "sha512-v3YHORv30/L7oUpceNgbnuzCJyAyTrK0DJU+mNwx1jm1NpFqyb+dlmDmuRPQR41kMaaQ9ven/ed6jzallC3QoA==",
       "requires": {
-        "axios": "0.26.0"
+        "axios": "0.25.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.26.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
-          "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
           "requires": {
-            "follow-redirects": "^1.14.8"
+            "follow-redirects": "^1.14.7"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rhoas/account-management-sdk": "0.27.0",
     "@rhoas/app-services-ui-components": "1.24.0",
     "@rhoas/app-services-ui-shared": "0.15.4",
-    "@rhoas/kafka-instance-sdk": "0.27.0",
+    "@rhoas/kafka-instance-sdk": "0.23.2",
     "@rhoas/kafka-management-sdk": "0.27.0",
     "@rhoas/registry-management-sdk": "0.27.0",
     "classnames": "2.3.1",


### PR DESCRIPTION
In latest `kafka-instance-sdk`, there are major changes which breaks the kafka-ui app and topics api call (admin api).
This is temporary fix. We need to fix all the changes with latest version of `kafka-instance-sdk` 

https://issues.redhat.com/browse/MGDSTRM-7832