### PR TITLE
Added the Settings page for RHOSR data plane

### DIFF
--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -22,6 +22,7 @@ const OverviewPage = React.lazy(() => import('@app/pages/Overview/OverviewPage')
 const ResourcesPage = React.lazy(() => import('@app/pages/Resources/ResourcesPage'));
 const RulesPage = React.lazy(() => import('@app/pages/ServiceRegistry/RulesPage'));
 const RolesPage = React.lazy(() => import('@app/pages/ServiceRegistry/RolesPage'));
+const SettingsPage = React.lazy(() => import('@app/pages/ServiceRegistry/SettingsPage'));
 const ServiceAccountsPage = React.lazy(() => import('@app/pages/ServiceAccounts/ServiceAccountsPage'));
 const CosPage = React.lazy(() => import('@app/pages/CosPage/CosPage'));
 const ServiceRegistryPage = React.lazy(() => import('@app/pages/ServiceRegistry/ServiceRegistryPage'));
@@ -102,6 +103,14 @@ const appRoutes: AppRouteConfig<any>[] = [
     exact: true,
     label: 'Service Registry',
     path: '/service-registry/t/:tenantId/roles',
+    title: 'Service Registry | Red Hat OpenShift Application Services',
+    basename: '/service-registry',
+  },
+  {
+    component: SettingsPage,
+    exact: true,
+    label: 'Service Registry',
+    path: '/service-registry/t/:tenantId/settings',
     title: 'Service Registry | Red Hat OpenShift Application Services',
     basename: '/service-registry',
   },

--- a/src/app/pages/ServiceRegistry/SettingsPage.tsx
+++ b/src/app/pages/ServiceRegistry/SettingsPage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { FederatedApicurioComponent } from "@app/pages/ServiceRegistry/FederatedApicurioComponent";
+import { SrsLayout } from "@app/pages/ServiceRegistry/SrsLayout";
+import { useConfig } from "@rhoas/app-services-ui-shared";
+import { ServiceDownPage } from "@app/pages";
+
+export const SettingsPage: React.FunctionComponent = () => {
+  const config = useConfig();
+
+  if (config?.serviceDown) {
+    return <ServiceDownPage />;
+  }
+
+  return <SettingsPageConnected />;
+};
+
+const SettingsPageConnected: React.FunctionComponent = () => {
+  return (
+    <SrsLayout breadcrumbId="srs.settings" render={registry => (
+      <FederatedApicurioComponent registry={registry} module="./FederatedSettingsPage"/>
+    )}/>
+  );
+};
+
+export default SettingsPage;

--- a/src/app/pages/ServiceRegistry/utils.ts
+++ b/src/app/pages/ServiceRegistry/utils.ts
@@ -53,6 +53,7 @@ const createApicurioConfig = (config: Config, apiUrl: string, navPathPrefix: str
       breadcrumbs: false,
       roleManagement: config.srs.apiBasePath == "https://api.stage.openshift.com",
       multiTenant: true,
+      settings: true
     },
     ui: {
       navPrefixPath: navPathPrefix,


### PR DESCRIPTION
This is a new page in the RHOSR data plane (admin only).  It's a peer of the Access and Global Rules pages.