### PR TITLE
fix: rhoas cli backwards compatiblity by updating changes

### DIFF
--- a/static/configs/service-constants.json
+++ b/static/configs/service-constants.json
@@ -4,8 +4,8 @@
     "ams": {
       "termsAndConditionsEventCode": "register",
       "termsAndConditionsSiteCode": "ocm",
-      "instanceQuotaId": "cluster|rhinfra|rhosak|marketplace",
-      "trialQuotaId": "cluster|rhinfra|rhosaktrial|marketplace",
+      "instanceQuotaId": "cluster|rhinfra|rhosak|standard",
+      "trialQuotaId": "cluster|rhinfra|rhosaktrial|standard",
       "quotaProductId": "RHOSAK",
       "trialQuotaProductId": "RHOSAKTrial",
       "resourceName": "rhosak"


### PR DESCRIPTION
UI implemented new method for calculating quota but we still need to fix existing RHOAS CLI instances that rely on the values that will be wrong. I will be making change in CLI to fix it but users will not get that instantly