### PR TITLE
fix: Decode path params before passing them to federated components

### DIFF
--- a/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
+++ b/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
@@ -6,7 +6,7 @@ import { useConfig } from "@rhoas/app-services-ui-shared";
 import { ServiceDownPage } from "@app/pages";
 
 export const ArtifactVersionDetails: React.FunctionComponent = () => {
-  const config = useConfig();  
+  const config = useConfig();
 
   if (config?.serviceDown) {
     return <ServiceDownPage />;
@@ -16,8 +16,9 @@ export const ArtifactVersionDetails: React.FunctionComponent = () => {
 };
 
 const ArtifactVersionDetailsConnected: React.FunctionComponent = () => {
-  const { artifactId }=useParams<{artifactId:string}>();
-  
+  let { artifactId }=useParams<{artifactId:string}>();
+  artifactId = decodeURIComponent(artifactId);
+
   return (
     <SrsLayout breadcrumbId="srs.artifacts_details" artifactId={artifactId} render={registry => (
       <FederatedApicurioComponent registry={registry} module="./FederatedArtifactVersionPage" />

--- a/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
+++ b/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
@@ -46,7 +46,10 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
   const basename = useBasename();
   const getToken = auth?.apicurio_registry.getToken;
 
-  const { groupId, artifactId, version } = useParams<ServiceRegistryParams>();
+  let { groupId, artifactId, version } = useParams<ServiceRegistryParams>();
+  groupId = decodeURIComponent(groupId);
+  artifactId = decodeURIComponent(artifactId);
+  version = decodeURIComponent(version);
 
   if (config === undefined || registry === undefined) {
     return <AppServicesLoading />;


### PR DESCRIPTION
If the user creates a registry artifact with, for example, a slash `/` character in the ID or group name, that artifact will not be accessible in the UI.  The reason is that the path params are not being URL decoded before being sent to the registry data plane UI federated components.
