### PR TITLE
Fixed a problem with duplicate "ads" section in the config

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -139,9 +139,6 @@
             }
           }
         },
-        "ads": {
-          "editorsBasePath": ""
-        },
         "smart_events": {
           "apiBasePath": "https://lcstem2z9g006s6.api.stage.openshift.com"
         }
@@ -190,9 +187,6 @@
               "module": "./config"
             }
           }
-        },
-        "ads": {
-          "editorsBasePath": ""
         },
         "smart_events": {
           "apiBasePath": ""


### PR DESCRIPTION
I'm not really sure what will happen in the browser when there are duplicate keys in a JSON file, but based on what I'm seeing on qaprodauth it looks like the second one wins.  In any case, I've removed the duplicate (empty) config.