### PR TITLE
fix: use backend admin server url

### DIFF
--- a/src/app/pages/Kafka/kafka-instance.ts
+++ b/src/app/pages/Kafka/kafka-instance.ts
@@ -7,28 +7,20 @@ import {
 } from "@rhoas/kafka-management-sdk";
 import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
 
-const DEFAULT_ADMIN_SERVER_URL_TEMPLATE = "https://admin-server-{}";
-
 /**
  * Join admin server url template with the kafka bootstrap host and return the kafka admin url.
  *
- * @param adminServerUrlTemplate The template that will be used to generate the full admin url from the kafka bootstrap_server_host.
- *                               The template must have a '{}' placeholder that will be substitute with the bootstrap_server_host.
  * @param kafkaRequest KafkaRequest
  * @returns The admin server full URL included the protocol and base path
  */
 
 export const getAdminServerUrl = (
-  adminServerUrlTemplate: string,
   kafkaRequest?: KafkaRequest
 ): string => {
-  if (kafkaRequest === undefined) {
-    throw new Error("kafkaRequest cannot be undefined");
+  if (!kafkaRequest || !kafkaRequest.admin_api_server_url) {
+    throw new Error("kafkaRequest admin server cannot be undefined");
   }
-  return adminServerUrlTemplate.replace(
-    "{}",
-    kafkaRequest.bootstrap_server_host || ""
-  );
+  return kafkaRequest.admin_api_server_url
 };
 
 export type KafkaInstance = {
@@ -101,7 +93,6 @@ export const useKafkaInstance = (
     ? {
         kafkaDetail: kafkaRequest as Required<KafkaRequestWithSize>,
         adminServerUrl: getAdminServerUrl(
-          kafka?.adminServerUrlTemplate || DEFAULT_ADMIN_SERVER_URL_TEMPLATE,
           kafkaRequest
         ),
       }

--- a/src/app/pages/Kafka/kafka-instance.ts
+++ b/src/app/pages/Kafka/kafka-instance.ts
@@ -14,13 +14,11 @@ import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
  * @returns The admin server full URL included the protocol and base path
  */
 
-export const getAdminServerUrl = (
-  kafkaRequest?: KafkaRequest
-): string => {
+export const getAdminServerUrl = (kafkaRequest?: KafkaRequest): string => {
   if (!kafkaRequest || !kafkaRequest.admin_api_server_url) {
     throw new Error("kafkaRequest admin server cannot be undefined");
   }
-  return kafkaRequest.admin_api_server_url
+  return kafkaRequest.admin_api_server_url;
 };
 
 export type KafkaInstance = {
@@ -91,9 +89,7 @@ export const useKafkaInstance = (
   return kafkaRequest
     ? {
         kafkaDetail: kafkaRequest as Required<KafkaRequestWithSize>,
-        adminServerUrl: getAdminServerUrl(
-          kafkaRequest
-        ),
+        adminServerUrl: getAdminServerUrl(kafkaRequest),
       }
     : kafkaRequest;
 };

--- a/src/app/pages/Kafka/kafka-instance.ts
+++ b/src/app/pages/Kafka/kafka-instance.ts
@@ -37,7 +37,6 @@ export const useKafkaInstance = (
 ): KafkaInstance | false | undefined => {
   const {
     kas: { apiBasePath },
-    kafka,
   } = useConfig();
   const {
     kas: { getToken },


### PR DESCRIPTION
This PR enables us to use admin server url that is returned by backend. 
This change was also introduced into CLI and have been running in production for long time. 

We need this to enable testing with kas-installer as well as to future proof admin server api requests for stage and prod. 


## Verification

1. Select your kafka on the list. You will be redirected to metrics view
2. Check if metrics view works fine (it can be empty if your kafka is new)
3. Navigate to topics. 
4. You should be able to see and view the topics. If no topics create new one.
