### PR TITLE
fix: add kas-installer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ After that we can run any of the federated UI component in `./modules` folder an
 
 ## Running UI against custom backend
 
-Developers running UI locally can use multiple environments to point as backends that UI should use for authentication. To point UI to different services please modify your configuration locally:
+Developers running UI locally can use multiple environments to point as backends that UI should use for authentication. To point UI to different services please modify [config.json configuration](https://github.com/redhat-developer/app-services-ui/blob/main/config/config.json) file on your local machine:
 
-https://github.com/redhat-developer/app-services-ui/blob/main/config/config.json
+
 
 For example for configuring UI to run against Kas-installer we can change  
 kas.apiBasePath value to our custom cluser
 
-Please note if you running service thru (kas-installer)[https://github.com/bf2fc6cc711aee1a0c2a/kas-installer] you might need to add different cors orgins settings in individual backends. 
+Please note if you running service thru [kas-installer](https://github.com/bf2fc6cc711aee1a0c2a/kas-installer) you might need to add different cors orgins settings in individual backends. 
 
 ## Contributing Guide
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,17 @@ First we need to download all external repositories by running a script.
 
 After that we can run any of the federated UI component in `./modules` folder and it will automatically be used by the app-services-ui
 
- 
+## Running UI against custom backend
+
+Developers running UI locally can use multiple environments to point as backends that UI should use for authentication. To point UI to different services please modify your configuration locally:
+
+https://github.com/redhat-developer/app-services-ui/blob/main/config/config.json
+
+For example for configuring UI to run against Kas-installer we can change  
+kas.apiBasePath value to our custom cluser
+
+Please note if you running service thru (kas-installer)[https://github.com/bf2fc6cc711aee1a0c2a/kas-installer] you might need to add different cors orgins settings in individual backends. 
+
 ## Contributing Guide
 
 [CONTRIBUTING](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -46,14 +46,12 @@ After that we can run any of the federated UI component in `./modules` folder an
 
 ## Running UI against custom backend
 
-Developers running UI locally can use multiple environments to point as backends that UI should use for authentication. To point UI to different services please modify [config.json configuration](https://github.com/redhat-developer/app-services-ui/blob/main/config/config.json) file on your local machine:
-
-
+Developers running app-services-ui on their local machines can point it to custom backends and authentication providers. To point UI to different backend we need to modify [config.json configuration](https://github.com/redhat-developer/app-services-ui/blob/main/config/config.json) file on your local machine.
 
 For example for configuring UI to run against Kas-installer we can change  
-kas.apiBasePath value to our custom cluser
+1kas.apiBasePath1 value to kafka url returned by kas-installer.
 
-Please note if you running service thru [kas-installer](https://github.com/bf2fc6cc711aee1a0c2a/kas-installer) you might need to add different cors orgins settings in individual backends. 
+For more information please refer to [kas-installer](https://github.com/bf2fc6cc711aee1a0c2a/kas-installer)
 
 ## Contributing Guide
 


### PR DESCRIPTION
There were so many requests recently related to be able to run UI locally with custom URLs for the service. This was deemed to be impossible before but it have been proven working right now with number of fixes merged into the UI itself. 

I would like to put some initial documentation for this that can be extended later