### PR TITLE
Inject alerts into the RHOSR data plane

### DIFF
--- a/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
+++ b/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
@@ -7,11 +7,12 @@ import { FederatedModule } from "@app/components";
 import { useHistory, useParams } from "react-router-dom";
 import { Registry } from "@rhoas/registry-management-sdk";
 import {
+  useAlert,
   useAuth,
   useBasename,
   useConfig,
-  Principal, useAlert
-} from '@rhoas/app-services-ui-shared';
+  Principal,
+} from "@rhoas/app-services-ui-shared";
 import { AppServicesLoading } from "@rhoas/app-services-ui-components";
 
 export type FederatedApicurioComponentProps = {
@@ -55,12 +56,12 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
   >
 > = ({ Component, registry, principals, ...rest }) => {
   let federateConfig: ConfigType;
+  const alert = useAlert();
   const auth = useAuth();
   const config = useConfig();
   const history = useHistory();
   const basename = useBasename();
   const getToken = auth?.apicurio_registry.getToken;
-  const alert = useAlert();
 
   let { groupId, artifactId, version } = useParams<ServiceRegistryParams>();
   groupId = decodeURIComponent(groupId);

--- a/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
+++ b/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
@@ -10,8 +10,8 @@ import {
   useAuth,
   useBasename,
   useConfig,
-  Principal,
-} from "@rhoas/app-services-ui-shared";
+  Principal, useAlert
+} from '@rhoas/app-services-ui-shared';
 import { AppServicesLoading } from "@rhoas/app-services-ui-components";
 
 export type FederatedApicurioComponentProps = {
@@ -60,6 +60,7 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
   const history = useHistory();
   const basename = useBasename();
   const getToken = auth?.apicurio_registry.getToken;
+  const alert = useAlert();
 
   let { groupId, artifactId, version } = useParams<ServiceRegistryParams>();
   groupId = decodeURIComponent(groupId);
@@ -73,6 +74,7 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
   if (getToken && basename) {
     federateConfig = createApicurioConfig(
       config,
+      alert,
       registry.registryUrl as string,
       `${basename.getBasename()}/t/${registry?.id}`,
       getToken,

--- a/src/app/pages/ServiceRegistry/utils.ts
+++ b/src/app/pages/ServiceRegistry/utils.ts
@@ -1,4 +1,4 @@
-import { Alert, Principal } from '@rhoas/app-services-ui-shared';
+import { Alert, Principal } from "@rhoas/app-services-ui-shared";
 import { Config } from "@rhoas/app-services-ui-shared";
 
 export interface FeaturesConfig {

--- a/src/app/pages/ServiceRegistry/utils.ts
+++ b/src/app/pages/ServiceRegistry/utils.ts
@@ -62,7 +62,7 @@ const createApicurioConfig = (
       roleManagement: true,
       multiTenant: true,
       settings: true,
-      alerts: alert
+      alerts: alert,
     },
     ui: {
       navPrefixPath: navPathPrefix,

--- a/src/app/pages/ServiceRegistry/utils.ts
+++ b/src/app/pages/ServiceRegistry/utils.ts
@@ -1,10 +1,13 @@
-import { Principal } from "@rhoas/app-services-ui-shared";
+import { Alert, Principal } from '@rhoas/app-services-ui-shared';
 import { Config } from "@rhoas/app-services-ui-shared";
 
 export interface FeaturesConfig {
   readOnly?: boolean;
   breadcrumbs?: boolean;
   multiTenant?: boolean;
+  roleManagement?: boolean;
+  settings?: boolean;
+  alerts?: Alert;
 }
 
 export interface ArtifactsConfig {
@@ -39,6 +42,7 @@ export interface ConfigType {
 
 const createApicurioConfig = (
   _config: Config,
+  alert: Alert,
   apiUrl: string,
   navPathPrefix: string,
   getToken: () => Promise<string> | undefined,
@@ -58,6 +62,7 @@ const createApicurioConfig = (
       roleManagement: true,
       multiTenant: true,
       settings: true,
+      alerts: alert
     },
     ui: {
       navPrefixPath: navPathPrefix,


### PR DESCRIPTION
I have updated the RHOSR data plane `Settings` page to send a toast alert whenever the user changes one of the settings.  In order to use the shared app-services-ui `Alert` hook, I need to inject it into the data plane layer's federated components.