### PR TITLE
chore: disable react-router-dom singleton

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -118,7 +118,6 @@ module.exports = (env, argv) => {
         exposes: {
           "./RootApp": path.resolve(__dirname, "./src/AppEntry.tsx"),
         },
-        exclude: ["react-router-dom"],
         shared: [
           {
             ...dependencies,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -136,7 +136,7 @@ module.exports = (env, argv) => {
               requiredVersion: peerDependencies["react-i18next"],
             },
             "react-router-dom": {
-              singleton: true,
+              singleton: false, // consoledot needs this to be off to be able to upgrade the router to v6. We don't need this to be a singleton, so let's keep this off
               requiredVersion: peerDependencies["react-router-dom"],
             },
             "@rhoas/app-services-ui-components": {


### PR DESCRIPTION
consoledot needs this to be off to be able to upgrade the router to v6. We don't need this to be a singleton, so let's keep this off.

@Hyperkid123 does this look right?