### PR TITLE
Pass the principals to the artifact version page

### DIFF
--- a/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
+++ b/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
@@ -1,9 +1,11 @@
-import { FunctionComponent } from "react";
+import { useState, useEffect, FunctionComponent } from "react";
 import { useParams } from "react-router-dom";
 import { FederatedApicurioComponent } from "@app/pages/ServiceRegistry/FederatedApicurioComponent";
 import { SrsLayout } from "@app/pages/ServiceRegistry/SrsLayout";
-import { useConfig } from "@rhoas/app-services-ui-shared";
+import { useConfig, useAuth } from "@rhoas/app-services-ui-shared";
 import { ServiceDownPage } from "@app/pages";
+import { usePrincipal } from "@app/components";
+import { AppServicesLoading } from "@rhoas/app-services-ui-components";
 
 export const ArtifactVersionDetails: FunctionComponent = () => {
   const config = useConfig();
@@ -19,16 +21,37 @@ const ArtifactVersionDetailsConnected: FunctionComponent = () => {
   let { artifactId } = useParams<{ artifactId: string }>();
   artifactId = decodeURIComponent(artifactId);
 
+  const [currentlyLoggedInuser, setCurrentlyLoggedInuser] = useState<string>();
+  const auth = useAuth();
+  const { getAllPrincipals } = usePrincipal();
+
+  useEffect(() => {
+    (async () => {
+      await auth?.getUsername()?.then((user) => setCurrentlyLoggedInuser(user));
+    })();
+  }, [auth]);
+
   return (
     <SrsLayout
       breadcrumbId="srs.artifacts_details"
       artifactId={artifactId}
-      render={(registry) => (
-        <FederatedApicurioComponent
-          registry={registry}
-          module="./FederatedArtifactVersionPage"
-        />
-      )}
+      render={(registry) => {
+        if (registry === undefined || currentlyLoggedInuser === undefined) {
+          return <AppServicesLoading />;
+        }
+
+        const principals = getAllPrincipals()?.filter(
+          (p) => p.id !== currentlyLoggedInuser && p.id !== registry?.owner
+        );
+
+        return (
+          <FederatedApicurioComponent
+            registry={registry}
+            module="./FederatedArtifactVersionPage"
+            principals={principals}
+          />
+        );
+      }}
     />
   );
 };


### PR DESCRIPTION
The artifact version page in the registry data plane has been modified to allow users to be able to change the ownership of an artifact.  In order to display a dropdown of users when doing this, we need the list of principals in the org.  These are passed in, same as in the Access page.