### PR TITLE
MGDCTRS-1519 fix: update nav event handling

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -34,12 +34,13 @@ export const App: FunctionComponent = () => {
     insights.chrome.init();
     const appId = getAppId();
     insights.chrome.identifyApp(appId);
-
     const unregister = insights.chrome.on("APP_NAVIGATION", (event) => {
-      const streamUrls = ["kafkas", "service-accounts", "resources"];
-      history.push(
-        `/${streamUrls.includes(event.navId) ? "streams/" : ""}${event.navId}`
-      );
+      if (event?.domEvent?.href) {
+        const pathName = event?.domEvent?.href
+          .replace("/application-services", "/")
+          .replace(/^\/\//gm, "/");
+        history.push(pathName);
+      }
     });
     return () => {
       unregister();


### PR DESCRIPTION
This change updates the app navigation event handling, navId is deprecated apparently.  This change pulls the URL out of the contained DOMEvent and adjusts it so that it will ideally match one of the defined application routes.

Thanks @Hyperkid123 for tracking this down :smile: 