### PR TITLE
Try to fix the principal issue take 2

### DIFF
--- a/src/app/hooks/usePrincipals.ts
+++ b/src/app/hooks/usePrincipals.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { Configuration, SecurityApi } from "@rhoas/kafka-management-sdk";
+import { PrincipalApi } from "@redhat-cloud-services/rbac-client";
+import {
+  Principal,
+  PrincipalType,
+  useAuth,
+  useConfig,
+} from "@rhoas/app-services-ui-shared";
+
+export function usePrincipals(): {
+  loading: boolean;
+  users: Principal[] | undefined;
+  services: Principal[] | undefined;
+  allPrincipals: Principal[] | undefined;
+} {
+  const config = useConfig();
+  const auth = useAuth();
+
+  const [loading, setLoading] = useState(true);
+  const [services, setServices] = useState<Principal[] | undefined>();
+  const [users, setUsers] = useState<Principal[] | undefined>();
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const accessToken = await auth.kas.getToken();
+        const basePath = config.rbac.basePath;
+        if (accessToken) {
+          const [usersResult, servicesResult] = await Promise.allSettled([
+            fetchUserAccounts(accessToken, basePath),
+            fetchServiceAccounts(accessToken, basePath),
+          ]);
+
+          if (usersResult.status === "fulfilled") {
+            setUsers(usersResult.value);
+          }
+          if (servicesResult.status === "fulfilled") {
+            setServices(servicesResult.value);
+          }
+        }
+      } catch {
+        setLoading(false);
+      }
+    })();
+  }, [auth, config]);
+
+  return {
+    loading,
+    users,
+    services,
+    allPrincipals:
+      users || services ? [...(users || []), ...(services || [])] : undefined,
+  };
+}
+
+async function fetchUserAccounts(accessToken: string, basePath: string) {
+  try {
+    const principalApi = new PrincipalApi({
+      accessToken,
+      basePath,
+    });
+
+    return await principalApi.listPrincipals(-1).then((response) =>
+      response.data.data.map((p) => {
+        return {
+          id: p.username,
+          principalType: PrincipalType.UserAccount,
+          displayName: `${p.first_name} ${p.last_name}`,
+          emailAddress: p.email,
+        } as Principal;
+      })
+    );
+  } catch (e) {
+    // temp fix - this API is only available to org admins
+    // needs a proper approach longer term
+    console.warn("app-services-ui fetchUserAccounts error", e);
+  }
+  return undefined;
+}
+
+async function fetchServiceAccounts(accessToken: string, basePath: string) {
+  try {
+    const securityApi = new SecurityApi({
+      accessToken,
+      basePath,
+    } as Configuration);
+    return await securityApi.getServiceAccounts().then((response) =>
+      response.data.items.map((sa) => {
+        return {
+          id: sa.client_id,
+          displayName: sa.name,
+          principalType: PrincipalType.ServiceAccount,
+        } as Principal;
+      })
+    );
+  } catch (e) {
+    console.warn("app-services-ui fetchServiceAccounts error", e);
+  }
+  return undefined;
+}

--- a/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
+++ b/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
@@ -1,15 +1,9 @@
-import {
-  FC,
-  LazyExoticComponent,
-  useEffect,
-  useState,
-  VoidFunctionComponent,
-} from "react";
+import { FC, LazyExoticComponent, VoidFunctionComponent } from "react";
 import {
   ConfigType,
   createApicurioConfig,
 } from "@app/pages/ServiceRegistry/utils";
-import { FederatedModule, usePrincipal } from "@app/components";
+import { FederatedModule } from "@app/components";
 import { useHistory, useParams } from "react-router-dom";
 import { Registry } from "@rhoas/registry-management-sdk";
 import {
@@ -17,9 +11,9 @@ import {
   useAuth,
   useBasename,
   useConfig,
-  Principal,
 } from "@rhoas/app-services-ui-shared";
 import { AppServicesLoading } from "@rhoas/app-services-ui-components";
+import { usePrincipals } from "@app/hooks/usePrincipals";
 
 export type FederatedApicurioComponentProps = {
   module: string;
@@ -66,19 +60,14 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
   const config = useConfig();
   const history = useHistory();
   const basename = useBasename();
-  const { getAllPrincipals } = usePrincipal();
-  const [principals, setPrincipals] = useState<Principal[]>();
+  const { loading: loadingPrincipals, allPrincipals } = usePrincipals();
   const getToken = auth?.apicurio_registry.getToken;
   let { groupId, artifactId, version } = useParams<ServiceRegistryParams>();
   groupId = decodeURIComponent(groupId);
   artifactId = decodeURIComponent(artifactId);
   version = decodeURIComponent(version);
 
-  useEffect(() => {
-    setPrincipals(getAllPrincipals());
-  }, [getAllPrincipals]);
-
-  if (config === undefined || registry === undefined) {
+  if (config === undefined || registry === undefined || loadingPrincipals) {
     return <AppServicesLoading />;
   }
 
@@ -89,7 +78,7 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
       registry.registryUrl as string,
       `${basename.getBasename()}/t/${registry?.id}`,
       getToken,
-      principals
+      allPrincipals
     );
     return (
       <Component

--- a/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
+++ b/src/app/pages/ServiceRegistry/FederatedApicurioComponent.tsx
@@ -1,4 +1,10 @@
-import { FC, LazyExoticComponent, VoidFunctionComponent } from "react";
+import {
+  FC,
+  LazyExoticComponent,
+  useEffect,
+  useState,
+  VoidFunctionComponent,
+} from "react";
 import {
   ConfigType,
   createApicurioConfig,
@@ -61,16 +67,16 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
   const history = useHistory();
   const basename = useBasename();
   const { getAllPrincipals } = usePrincipal();
+  const [principals, setPrincipals] = useState<Principal[]>();
   const getToken = auth?.apicurio_registry.getToken;
-  const getPrincipals: () => Principal[] = () => {
-    const principals: Principal[] = getAllPrincipals() || [];
-    return principals;
-  };
-
   let { groupId, artifactId, version } = useParams<ServiceRegistryParams>();
   groupId = decodeURIComponent(groupId);
   artifactId = decodeURIComponent(artifactId);
   version = decodeURIComponent(version);
+
+  useEffect(() => {
+    setPrincipals(getAllPrincipals());
+  }, [getAllPrincipals]);
 
   if (config === undefined || registry === undefined) {
     return <AppServicesLoading />;
@@ -83,7 +89,7 @@ const ServiceAccountsPageConnected: VoidFunctionComponent<
       registry.registryUrl as string,
       `${basename.getBasename()}/t/${registry?.id}`,
       getToken,
-      getPrincipals
+      principals
     );
     return (
       <Component


### PR DESCRIPTION
Passing a function to the federate component didn't work consistently.  Sometimes it worked and sometimes it didn't. Likely I don't quite understand how callback functions are created and passed around in a react application.

This time, I'm trying to fix the issue using react constructs, specifically `useEffect` and `useState`.  Now the principal array is a state variable in the component, and that state variable is updated whenever the `getAllPrincipals` function changes.  If I understand how `usePrincipal` is written (and how React's `useCallback` works with memoized functions) then the `getAllPrincipals` function should change only when the underlying data changes (the data is fetched asynchronously).  When that happens, the new effect should fetch the principals using that function and store it in the state variable.  Presumably, when the state variable changes, the `<Component>` will be rebuilt (with the new array of principals).

The last part I'm uncertain about.  I would have liked to show a spinner until the `getAllPrincipals` was ready to be invoked with all the principals.  But I don't see a way to do that with the current implementation of `usePrincipal`.  Before the principal data is fetched asynchronously, it looks like the `getAllPrincipals` function will return an empty array rather than something like `undefined` which could indicate that the data isn't ready yet.  I don't think we can use empty array to indicate "not ready", because the org may legitimately not have any service accounts, and the user might not be an org admin (only org admins can see the list of user principals in the org, according to a comment in the code).
