### PR TITLE
Artifact version page must rerender when the `version` changes

### DIFF
--- a/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
+++ b/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
@@ -18,8 +18,12 @@ export const ArtifactVersionDetails: FunctionComponent = () => {
 };
 
 const ArtifactVersionDetailsConnected: FunctionComponent = () => {
+  let { groupId } = useParams<{ groupId: string }>();
+  groupId = decodeURIComponent(groupId);
   let { artifactId } = useParams<{ artifactId: string }>();
   artifactId = decodeURIComponent(artifactId);
+  let { version } = useParams<{ version: string }>();
+  version = decodeURIComponent(version);
 
   return (
     <SrsLayout

--- a/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
+++ b/src/app/pages/ServiceRegistry/ArtifactVersion.tsx
@@ -18,17 +18,21 @@ export const ArtifactVersionDetails: FunctionComponent = () => {
 };
 
 const ArtifactVersionDetailsConnected: FunctionComponent = () => {
-  let { groupId } = useParams<{ groupId: string }>();
+  let { groupId, artifactId, version } = useParams<{
+    groupId: string;
+    artifactId: string;
+    version: string;
+  }>();
   groupId = decodeURIComponent(groupId);
-  let { artifactId } = useParams<{ artifactId: string }>();
   artifactId = decodeURIComponent(artifactId);
-  let { version } = useParams<{ version: string }>();
   version = decodeURIComponent(version);
 
   return (
     <SrsLayout
       breadcrumbId="srs.artifacts_details"
+      groupId={groupId}
       artifactId={artifactId}
+      version={version}
       render={(registry) => (
         <ArtifactVersionDetailsLayoutRender registry={registry} />
       )}

--- a/src/app/pages/ServiceRegistry/SrsLayout.tsx
+++ b/src/app/pages/ServiceRegistry/SrsLayout.tsx
@@ -8,7 +8,9 @@ import { useAuth } from "@app/providers/auth";
 type SrsLayoutProps = {
   render: (registry: Registry) => JSX.Element;
   breadcrumbId?: string;
+  groupId?: string;
   artifactId?: string;
+  version?: string;
 };
 
 export const SrsLayout: FC<SrsLayoutProps> = (props) => {
@@ -26,7 +28,7 @@ export const SrsLayout: FC<SrsLayoutProps> = (props) => {
 
 const SrsLayoutConnected: VoidFunctionComponent<
   { Component: LazyExoticComponent<any> } & SrsLayoutProps
-> = ({ Component, render, breadcrumbId, artifactId }) => {
+> = ({ Component, render, breadcrumbId, groupId, artifactId, version }) => {
   const auth = useAuth();
 
   return (
@@ -35,7 +37,9 @@ const SrsLayoutConnected: VoidFunctionComponent<
         render={render}
         breadcrumbId={breadcrumbId}
         tokenEndPointUrl={auth?.tokenEndPointUrl}
+        groupId={groupId}
         artifactId={artifactId}
+        version={version}
         renderDownloadArtifacts={(
           registry: Registry,
           downloadLabel?: string


### PR DESCRIPTION
Need to include both `groupId` and `version` as params to `SrsLayout` so that the federated apicurio component is recreated when either of those params changes.