### PR TITLE
chore: MGDCTRS-1775 remove service preview banner

### DIFF
--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -288,7 +288,6 @@ const appRoutes: AppRouteConfig<unknown>[] = [
     path: "/connectors",
     title: "Connectors | Red Hat OpenShift Application Services",
     basename: `${getBaseName(window.location.pathname)}/connectors`,
-    devPreview: true,
   },
   {
     component: ServiceAccountsPage,


### PR DESCRIPTION
This change removes the service preview banner from the connectors service app.